### PR TITLE
feat: add fixable column and CSV output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Fork of [mhipszki/eslint-formatter-summary](https://github.com/mhipszki/eslint-f
 
 ## Features
 
-- aggregated errors / warnings **per rule**
+- aggregated errors / warnings / fixable count **per rule**
 - **sort by** rule name, number of errors or warnings
-- _NEW:_ output **markdown**
+- output as **markdown table** or **CSV**
 
 ## TL;DR
 
@@ -37,15 +37,21 @@ EFS_SORT_BY=rule EFS_SORT_DESC=true eslint -f @voxpelli/eslint-formatter-summary
 npm i -D @voxpelli/eslint-formatter-summary
 ```
 
+## Requirements
+
+| Tool       | Version                           | Field in [`package.json`](package.json) |
+| ---------- | --------------------------------- | ------------------------- |
+| Node.js    | The LTS releases of Node.js       | `engines.node`            |
+| TypeScript | Version `>=5.9` (optional)        | `engines.typescript`      |
+| ESLint     | Version `>=9` (only flat configs) | `peerDependencies.eslint` |
+
 ## How to use
 
-When you run ESLint just specify `@voxpelli/eslint-formatter-summary` as the formatter:
+When you run ESLint specify `@voxpelli/eslint-formatter-summary` as the formatter (see [ESLint CLI documentation](http://eslint.org/docs/user-guide/command-line-interface#-f---format)):
 
 ```shell
 eslint -f @voxpelli/eslint-formatter-summary [file|dir|glob]*
 ```
-
-See http://eslint.org/docs/user-guide/command-line-interface#-f---format
 
 ## Intention
 
@@ -87,7 +93,7 @@ sorted string results are shown in ASCENDING order by default and numbers in DES
 EFS_SORT_BY=rule EFS_SORT_REVERSE=true eslint -f @voxpelli/eslint-formatter-summary ./src
 ```
 
-### Changing output format
+### Markdown output
 
 To output the summary as a markdown table, set `EFS_OUTPUT=markdown`
 
@@ -97,19 +103,38 @@ EFS_OUTPUT=markdown eslint -f @voxpelli/eslint-formatter-summary ./src
 
 Example:
 
-| Errors | Warnings | Rule            |
-| ------ | -------- | --------------- |
-|      1 |        0 | <details><summary>[no-const-assign](https://eslint.org/docs/rules/no-const-assign)</summary><ul><li>test.js</li></ul></details> |
-|      1 |        0 | <details><summary>[no-undef](https://eslint.org/docs/rules/no-undef)</summary><ul><li>test.js</li></ul></details> |
-|      1 |        0 | <details><summary>[no-unused-vars](https://eslint.org/docs/rules/no-unused-vars)</summary><ul><li>test.js</li></ul></details> |
+| Errors | Warnings | Fixable | Rule            |
+| ------ | -------- | ------- | --------------- |
+|      1 |        - |       1 | <details><summary>[no-const-assign](https://eslint.org/docs/rules/no-const-assign)</summary><ul><li>test.js</li></ul></details> |
+|      1 |        - |       - | <details><summary>[no-undef](https://eslint.org/docs/rules/no-undef)</summary><ul><li>test.js</li></ul></details> |
+|      1 |        - |       - | <details><summary>[no-unused-vars](https://eslint.org/docs/rules/no-unused-vars)</summary><ul><li>test.js</li></ul></details> |
 
-## Supported Node versions
+The raw example markdown:
 
-This project targets the current LTS releases of Node.js. See [`engines.node` in `package.json`](package.json).
+```markdown
+| Errors | Warnings | Fixable | Rule            |
+| ------ | -------- | ------- | --------------- |
+|      1 |        - |       1 | <details><summary>[no-const-assign](https://eslint.org/docs/rules/no-const-assign)</summary><ul><li>test.js</li></ul></details> |
+|      1 |        - |       - | <details><summary>[no-undef](https://eslint.org/docs/rules/no-undef)</summary><ul><li>test.js</li></ul></details> |
+|      1 |        - |       - | <details><summary>[no-unused-vars](https://eslint.org/docs/rules/no-unused-vars)</summary><ul><li>test.js</li></ul></details> |
+```
 
-## Supported ESLint versions
+### CSV output
 
-`ESLint` versions are supported from `v8` onwards.
+To output the summary as CSV, set `EFS_OUTPUT=csv`
+
+```shell
+EFS_OUTPUT=csv eslint -f @voxpelli/eslint-formatter-summary ./src
+```
+
+Example:
+
+```csv
+errors,warnings,fixable,rule
+1,0,1,"no-const-assign"
+1,0,0,"no-undef"
+1,0,0,"no-unused-vars"
+```
 
 ## Contribute
 

--- a/lib/format-results.js
+++ b/lib/format-results.js
@@ -15,6 +15,8 @@ const maxErrorLen = (rules) => lengthOfLongest('errors', rules);
 /** @type {CountingHelper} */
 const maxWarningLen = (rules) => lengthOfLongest('warnings', rules);
 /** @type {CountingHelper} */
+const maxFixableLen = (rules) => lengthOfLongest('fixable', rules);
+/** @type {CountingHelper} */
 const maxRuleLen = (rules) => lengthOfLongest('ruleId', rules);
 
 /** @type {CountingHelper} */
@@ -22,10 +24,13 @@ const totalErrors = (rules) => sum('errors', rules);
 /** @type {CountingHelper} */
 const totalWarnings = (rules) => sum('warnings', rules);
 /** @type {CountingHelper} */
+const totalFixable = (rules) => sum('fixable', rules);
+/** @type {CountingHelper} */
 const totalProblems = (rules) => totalErrors(rules) + totalWarnings(rules);
 
 const HEAD_ERROR = 'Errors';
 const HEAD_WARNING = 'Warnings';
+const HEAD_FIXABLE = 'Fixable';
 const HEAD_RULE = 'Rule';
 
 /**
@@ -58,21 +63,19 @@ const constructHeader = (rules, { markdown }) => {
   if (markdown) {
     const maxError = Math.max(HEAD_ERROR.length, maxErrorLen(rules));
     const maxWarning = Math.max(HEAD_WARNING.length, maxWarningLen(rules));
+    const maxFixable = Math.max(HEAD_FIXABLE.length, maxFixableLen(rules));
     const maxRule = Math.max(HEAD_RULE.length, maxRuleLen(rules));
 
     return (
-      `| ${HEAD_ERROR.padEnd(maxError)} | ${HEAD_WARNING.padEnd(
-        maxWarning
-      )} | ${HEAD_RULE.padEnd(maxRule)} |\n` +
-      `| ${'-'.repeat(maxError)} | ${'-'.repeat(maxWarning)} | ${'-'.repeat(
-        maxRule
-      )} |`
+      `| ${HEAD_ERROR.padEnd(maxError)} | ${HEAD_WARNING.padEnd(maxWarning)} | ${HEAD_FIXABLE.padEnd(maxFixable)} | ${HEAD_RULE.padEnd(maxRule)} |\n` +
+      `| ${'-'.repeat(maxError)} | ${'-'.repeat(maxWarning)} | ${'-'.repeat(maxFixable)} | ${'-'.repeat(maxRule)} |`
     );
   }
   const errors = '0'.repeat(maxErrorLen(rules));
   const warnings = '0'.repeat(maxWarningLen(rules));
+  const fixable = '0'.repeat(maxFixableLen(rules));
   const longestRule = '0'.repeat(maxRuleLen(rules));
-  const len = `${errors} errors | ${warnings} warnings | rule: ${longestRule}`
+  const len = `${errors} errors | ${warnings} warnings | ${fixable} fixable | rule: ${longestRule}`
     .length;
   const header = ' Summary of failing ESLint rules '.padEnd(len);
   return chalk.bgRed(header);
@@ -92,12 +95,17 @@ const constructSummary = (rules, { markdown, rulesMeta }) => {
     markdown ? HEAD_WARNING.length : 0,
     maxWarningLen(rules)
   );
+  const maxFixable = Math.max(
+    markdown ? HEAD_FIXABLE.length : 0,
+    maxFixableLen(rules)
+  );
   const maxRule = Math.max(markdown ? HEAD_RULE.length : 0, maxRuleLen(rules));
 
   return rules
     .map((rule, i) => {
       const errors = pad(rule.errors, maxError);
       const warnings = pad(rule.warnings, maxWarning);
+      const fixable = pad(rule.fixable, maxFixable);
       const { relativeFilePaths, ruleId } = rule;
       const meta = rulesMeta[ruleId] || {};
       const docsUrl = (meta.docs || {}).url;
@@ -106,11 +114,13 @@ const constructSummary = (rules, { markdown, rulesMeta }) => {
         : '';
 
       const line = markdown
-        ? `| ${errors} | ${warnings} | <details><summary>${markdownLink(ruleId, docsUrl).padEnd(maxRule)}</summary>${filesList}</details> |`
+        ? `| ${errors} | ${warnings} | ${fixable} | <details><summary>${markdownLink(ruleId, docsUrl).padEnd(maxRule)}</summary>${filesList}</details> |`
         : `${
             dimIfZero(chalk.red(errors) + ' errors', rule.errors)
           } | ${
             dimIfZero(chalk.yellow(warnings) + ' warnings', rule.warnings)
+          } | ${
+            dimIfZero(chalk.green(fixable) + ' fixable', rule.fixable)
           } | rule: ${
             chalk.bold(cliLink(ruleId, docsUrl))
           }`;
@@ -130,7 +140,26 @@ const constructTotal = (rules) =>
     totalErrors(rules) + chalk.red(' errors')
   }, ${
     totalWarnings(rules) + chalk.yellow(' warnings')
+  }, ${
+    totalFixable(rules) + chalk.green(' fixable')
   })`;
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+const csvField = (value) => `"${value.split('"').join('""')}"`;
+
+/**
+ * @param {MessageSummary[]} rules
+ * @returns {string}
+ */
+const constructCsv = (rules) => {
+  const rows = rules.map(({ errors, fixable, ruleId, warnings }) =>
+    `${errors},${warnings},${fixable},${csvField(ruleId)}`
+  );
+  return ['errors,warnings,fixable,rule', ...rows].join('\n');
+};
 
 /**
  * @typedef FormatOptions
@@ -168,6 +197,8 @@ export function format (results, options) {
       );
 
   sortBy(prop, rules, sortReverse);
+
+  if (output === 'csv') return constructCsv(rules);
 
   const markdown = output === 'markdown';
 

--- a/lib/format-results.js
+++ b/lib/format-results.js
@@ -106,18 +106,17 @@ const constructSummary = (rules, { markdown, rulesMeta }) => {
     : pad;
 
   return rules
-    .map((rule, i) => {
+    .map((rule) => {
       const errors = cell(rule.errors, maxError);
       const warnings = cell(rule.warnings, maxWarning);
       const fixable = cell(rule.fixable, maxFixable);
       const { relativeFilePaths, ruleId } = rule;
-      const meta = rulesMeta[ruleId] || {};
-      const docsUrl = (meta.docs || {}).url;
+      const docsUrl = rulesMeta[ruleId]?.docs?.url;
       const filesList = markdown
         ? `<ul><li>${[...relativeFilePaths].join('</li><li>')}</li></ul>`
         : '';
 
-      const line = markdown
+      return markdown
         ? `| ${errors} | ${warnings} | ${fixable} | <details><summary>${markdownLink(ruleId, docsUrl).padEnd(maxRule)}</summary>${filesList}</details> |`
         : `${
             dimIfZero(chalk.red(errors) + ' errors', rule.errors)
@@ -128,9 +127,8 @@ const constructSummary = (rules, { markdown, rulesMeta }) => {
           } | rule: ${
             chalk.bold(cliLink(ruleId, docsUrl))
           }`;
-      return i < rules.length - 1 ? `${line}\n` : line;
     })
-    .join('');
+    .join('\n');
 };
 
 /**
@@ -152,7 +150,7 @@ const constructTotal = (rules) =>
  * @param {string} value
  * @returns {string}
  */
-const csvField = (value) => `"${value.split('"').join('""')}"`;
+const csvField = (value) => `"${value.replaceAll('"', '""')}"`;
 
 /**
  * @param {MessageSummary[]} rules
@@ -190,8 +188,6 @@ export function format (results, options) {
     sortReverse = false,
   } = options;
 
-  const rules = aggregate(results, { cwd });
-
   const prop = sortByProp === 'rule'
     ? ['ruleId']
     : (
@@ -200,7 +196,7 @@ export function format (results, options) {
           : ['errors', 'warnings', 'ruleId']
       );
 
-  sortBy(prop, rules, sortReverse);
+  const rules = sortBy(prop, aggregate(results, { cwd }), sortReverse);
 
   if (output === 'csv') return constructCsv(rules);
 

--- a/lib/format-results.js
+++ b/lib/format-results.js
@@ -101,11 +101,15 @@ const constructSummary = (rules, { markdown, rulesMeta }) => {
   );
   const maxRule = Math.max(markdown ? HEAD_RULE.length : 0, maxRuleLen(rules));
 
+  const cell = markdown
+    ? (/** @type {number} */ n, /** @type {number} */ len) => n === 0 ? '-'.padStart(len) : pad(n, len)
+    : pad;
+
   return rules
     .map((rule, i) => {
-      const errors = pad(rule.errors, maxError);
-      const warnings = pad(rule.warnings, maxWarning);
-      const fixable = pad(rule.fixable, maxFixable);
+      const errors = cell(rule.errors, maxError);
+      const warnings = cell(rule.warnings, maxWarning);
+      const fixable = cell(rule.fixable, maxFixable);
       const { relativeFilePaths, ruleId } = rule;
       const meta = rulesMeta[ruleId] || {};
       const docsUrl = (meta.docs || {}).url;

--- a/lib/process-message.js
+++ b/lib/process-message.js
@@ -22,7 +22,7 @@ const processMessage = (summary, message) => {
     severity,
   } = message;
 
-  const ruleId = message.ruleId !== null ? message.ruleId : 'syntax error';
+  const ruleId = message.ruleId ?? 'syntax error';
   const errors = severity === 2 ? 1 : 0;
   const warnings = severity === 1 ? 1 : 0;
   const fixable = message.fix !== undefined ? 1 : 0;

--- a/lib/process-message.js
+++ b/lib/process-message.js
@@ -5,6 +5,7 @@ import findRule from './find-rule.js';
  * @property {string} ruleId
  * @property {number} errors
  * @property {number} warnings
+ * @property {number} fixable
  * @property {Set<string>} relativeFilePaths
  */
 
@@ -24,6 +25,7 @@ const processMessage = (summary, message) => {
   const ruleId = message.ruleId !== null ? message.ruleId : 'syntax error';
   const errors = severity === 2 ? 1 : 0;
   const warnings = severity === 1 ? 1 : 0;
+  const fixable = message.fix !== undefined ? 1 : 0;
   const rule = findRule(summary, ruleId);
 
   if (!rule) {
@@ -31,11 +33,13 @@ const processMessage = (summary, message) => {
       ruleId,
       errors,
       warnings,
+      fixable,
       relativeFilePaths: new Set([filePathRelative]),
     });
   } else {
     rule.errors += errors;
     rule.warnings += warnings;
+    rule.fixable += fixable;
     rule.relativeFilePaths.add(filePathRelative);
   }
   return summary;

--- a/lib/sort-by-prop.js
+++ b/lib/sort-by-prop.js
@@ -28,10 +28,9 @@ const checkProp = (a, b, [prop, ...props], sortReverse) => {
  * @param {string[]} props
  * @param {Array<Record<string, any>>} array
  * @param {boolean} sortReverse
- * @returns {void}
+ * @returns {Array<Record<string, any>>}
  */
-const sortBy = (props, array, sortReverse) => {
-  array.sort((a, b) => checkProp(a, b, props, sortReverse));
-};
+const sortBy = (props, array, sortReverse) =>
+  array.toSorted((a, b) => checkProp(a, b, props, sortReverse));
 
 export default sortBy;

--- a/lib/sort-by-prop.js
+++ b/lib/sort-by-prop.js
@@ -25,10 +25,11 @@ const checkProp = (a, b, [prop, ...props], sortReverse) => {
 };
 
 /**
+ * @template {Record<string, any>} T
  * @param {string[]} props
- * @param {Array<Record<string, any>>} array
+ * @param {T[]} array
  * @param {boolean} sortReverse
- * @returns {Array<Record<string, any>>}
+ * @returns {T[]}
  */
 const sortBy = (props, array, sortReverse) =>
   array.toSorted((a, b) => checkProp(a, b, props, sortReverse));

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lib/*.js"
   ],
   "scripts": {
-    "check:installed-check": "installed-check",
+    "check:installed-check": "installed-check -i @voxpelli/eslint-config",
     "check:knip": "knip",
     "check:lint": "eslint lib/ index.cjs",
     "check:tsc": "tsc",
@@ -51,7 +51,7 @@
     "terminal-link": "^3.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=9"
+    "eslint": ">=9.13.0"
   },
   "devDependencies": {
     "@types/node": "^20.19.39",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "chalk": "^5.1.2",
     "terminal-link": "^3.0.0"
   },
+  "peerDependencies": {
+    "eslint": ">=9"
+  },
   "devDependencies": {
     "@types/node": "^22.19.17",
     "@voxpelli/eslint-config": "^23.0.0",

--- a/package.json
+++ b/package.json
@@ -56,13 +56,13 @@
   "devDependencies": {
     "@types/node": "^20.19.39",
     "@voxpelli/eslint-config": "^23.0.0",
-    "@voxpelli/tsconfig": "^16.1.0",
+    "@voxpelli/tsconfig": "^16.2.1",
     "eslint": "^9.39.4",
     "husky": "^9.1.7",
     "installed-check": "^10.0.1",
     "knip": "^6.4.1",
     "npm-run-all2": "^8.0.4",
     "type-coverage": "^2.29.7",
-    "typescript": "~5.9.0"
+    "typescript": "~6.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint": ">=9"
   },
   "devDependencies": {
-    "@types/node": "^22.19.17",
+    "@types/node": "^20.19.39",
     "@voxpelli/eslint-config": "^23.0.0",
     "@voxpelli/tsconfig": "^16.1.0",
     "eslint": "^9.39.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@voxpelli/tsconfig/node14.json",
+  "extends": "@voxpelli/tsconfig/node20.json",
   "files": [
     "index.cjs"
   ],


### PR DESCRIPTION
## Summary

- Adds a **Fixable** column to all output formats (CLI, markdown) showing how many violations of each rule are auto-fixable via `eslint --fix`
- Adds **`EFS_OUTPUT=csv`** as a new machine-readable output format
- Fixable counts are tracked per-message using `message.fix !== undefined`, giving accurate per-violation counts rather than just flagging whether a rule *can* produce fixes

## Details

### Fixable column

Appears in CLI output as `N fixable` (green when non-zero, dimmed when zero) and in the total line: `22 problems in total (18 errors, 4 warnings, 2 fixable)`. In markdown, zeros are shown as `-` to reduce visual noise:

```markdown
| Errors | Warnings | Fixable | Rule                     |
| ------ | -------- | ------- | ------------------------ |
|     10 |        - |       - | no-const-assign          |
|      1 |        - |       1 | unicorn/no-null          |
|      - |        1 |       - | no-console               |
|      - |        1 |       1 | unicorn/prefer-spread    |
```

### CSV format

Outputs a header row + one row per rule, activated via `EFS_OUTPUT=csv`:

```csv
errors,warnings,fixable,rule
10,0,0,"no-const-assign"
1,0,1,"unicorn/no-null"
0,1,0,"no-console"
0,1,1,"unicorn/prefer-spread"
```

## Test plan

- [x] `npm run check` — lint, types, knip all pass
- [x] `npm run test:real-world` — plain output includes fixable column and updated total
- [x] `EFS_OUTPUT=csv npm run try test.js` — CSV output with correct fixable counts
- [x] `EFS_OUTPUT=markdown npm run try test.js` — markdown table includes Fixable column

🤖 Generated with [Claude Code](https://claude.com/claude-code)