### PR TITLE
feat: write markdown summary to $GITHUB_STEP_SUMMARY

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ errors,warnings,fixable,rule
 1,0,0,"no-unused-vars"
 ```
 
+### GitHub Actions
+
+When running under GitHub Actions, the formatter automatically appends its markdown output to [`$GITHUB_STEP_SUMMARY`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-job-summary), so failing rules surface on the job summary page. This happens regardless of `EFS_OUTPUT` — stdout still uses whatever format you configured.
+
+- Skipped when the run is clean (no errors and no warnings).
+- Opt out with `EFS_GITHUB_STEP_SUMMARY=false` (or `0`) — useful for jobs that should only emit the formatter's stdout.
+- If the write fails (e.g. read-only path), a warning is logged to stderr but the lint run continues.
+
 ## Contribute
 
 Please feel free to submit an issue describing your proposal you would like to discuss. PRs are also welcome!

--- a/index.cjs
+++ b/index.cjs
@@ -30,7 +30,8 @@ module.exports = async function formatter (results, { cwd, rulesMeta }) {
     try {
       await appendFile(GITHUB_STEP_SUMMARY, markdown + '\n', 'utf8');
     } catch (err) {
-      process.stderr.write(`eslint-formatter-summary: failed to append to $GITHUB_STEP_SUMMARY: ${/** @type {Error} */ (err).message}\n`);
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`eslint-formatter-summary: failed to append to $GITHUB_STEP_SUMMARY (${GITHUB_STEP_SUMMARY}): ${errorMessage}\n`);
     }
   }
 

--- a/index.cjs
+++ b/index.cjs
@@ -24,7 +24,11 @@ module.exports = async function formatter (results, { cwd, rulesMeta }) {
       ? output
       : format(results, { ...options, output: 'markdown' });
     const { appendFile } = await import('node:fs/promises');
-    await appendFile(GITHUB_STEP_SUMMARY, markdown + '\n', 'utf8');
+    try {
+      await appendFile(GITHUB_STEP_SUMMARY, markdown + '\n', 'utf8');
+    } catch (err) {
+      process.stderr.write(`eslint-formatter-summary: failed to append to $GITHUB_STEP_SUMMARY: ${/** @type {Error} */ (err).message}\n`);
+    }
   }
 
   return output;

--- a/index.cjs
+++ b/index.cjs
@@ -7,14 +7,25 @@
  */
 module.exports = async function formatter (results, { cwd, rulesMeta }) {
   // eslint-disable-next-line n/no-process-env
-  const { EFS_OUTPUT, EFS_SORT_BY, EFS_SORT_REVERSE } = process.env;
+  const { EFS_OUTPUT, EFS_SORT_BY, EFS_SORT_REVERSE, GITHUB_STEP_SUMMARY } = process.env;
   const { format } = await import('./lib/format-results.js');
 
-  return format(results, {
+  const options = {
     cwd,
-    output: EFS_OUTPUT,
     sortByProp: EFS_SORT_BY,
     sortReverse: EFS_SORT_REVERSE === 'true',
     rulesMeta,
-  });
+  };
+
+  const output = format(results, { ...options, output: EFS_OUTPUT });
+
+  if (GITHUB_STEP_SUMMARY) {
+    const markdown = EFS_OUTPUT === 'markdown'
+      ? output
+      : format(results, { ...options, output: 'markdown' });
+    const { appendFile } = await import('node:fs/promises');
+    await appendFile(GITHUB_STEP_SUMMARY, markdown + '\n', 'utf8');
+  }
+
+  return output;
 };

--- a/index.cjs
+++ b/index.cjs
@@ -7,7 +7,7 @@
  */
 module.exports = async function formatter (results, { cwd, rulesMeta }) {
   // eslint-disable-next-line n/no-process-env
-  const { EFS_OUTPUT, EFS_SORT_BY, EFS_SORT_REVERSE, GITHUB_STEP_SUMMARY } = process.env;
+  const { EFS_GITHUB_STEP_SUMMARY, EFS_OUTPUT, EFS_SORT_BY, EFS_SORT_REVERSE, GITHUB_STEP_SUMMARY } = process.env;
   const { format } = await import('./lib/format-results.js');
 
   const options = {
@@ -19,7 +19,10 @@ module.exports = async function formatter (results, { cwd, rulesMeta }) {
 
   const output = format(results, { ...options, output: EFS_OUTPUT });
 
-  if (GITHUB_STEP_SUMMARY) {
+  const summaryOptedOut = EFS_GITHUB_STEP_SUMMARY === 'false' || EFS_GITHUB_STEP_SUMMARY === '0';
+  const hasFindings = results.some(result => result.errorCount > 0 || result.warningCount > 0);
+
+  if (GITHUB_STEP_SUMMARY && !summaryOptedOut && hasFindings) {
     const markdown = EFS_OUTPUT === 'markdown'
       ? output
       : format(results, { ...options, output: 'markdown' });


### PR DESCRIPTION
## Summary
- When `$GITHUB_STEP_SUMMARY` is set (GitHub Actions), append the markdown variant of the rule summary to that file so the run page renders a rendered rule table.
- Zero config; stdout output is unchanged. Outside CI the env var is unset, so behavior is identical to today.
- Reuses the existing markdown output path — no changes under `lib/`.
- If `EFS_OUTPUT=markdown` is already set, the same string is reused (no double work); otherwise a second `format()` call produces the markdown for the summary file only.

## Test plan
- [x] `npm test` passes (lint, tsc, knip, installed-check, type-coverage, real-world)
- [x] Outside CI: stdout output unchanged
- [x] `GITHUB_STEP_SUMMARY=/tmp/x.md eslint -f ./index.cjs <files>` writes a markdown table to `/tmp/x.md`
- [x] `EFS_OUTPUT=csv` + `GITHUB_STEP_SUMMARY=/tmp/x.md` → stdout is CSV, file gets markdown
- [ ] End-to-end: confirm a real GitHub Actions run renders the summary panel on the job page

🤖 Generated with [Claude Code](https://claude.com/claude-code)