### PR TITLE
test: add node:test + c8 unit test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,18 @@
-/dist
-/node_modules
+# Basic ones
 /coverage
+/coverage-ts
+/node_modules
+/.env
+/.nyc_output
+
+# We're a library, so please, no lock files
+/package-lock.json
+/yarn.lock
+
+# Library specific ones
+/dist
 .coveralls.yml
 yarn-error.log
-yarn.lock
+
+# Local agent / assistant state
+CLAUDE.md

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "husky-enable": "husky",
     "husky-disable": "git config --unset core.hooksPath",
     "test-ci": "run-s test:*",
+    "test:node": "c8 --reporter=lcov --reporter=text node --test test/*.test.js",
     "test:real-world": "eslint -f ./index.cjs lib/",
     "test": "run-s check test:*",
     "try": "eslint -f ./index.cjs"
@@ -58,6 +59,7 @@
     "@types/node": "^20.19.39",
     "@voxpelli/eslint-config": "^23.0.0",
     "@voxpelli/tsconfig": "^16.2.1",
+    "c8": "^11.0.0",
     "eslint": "^9.39.4",
     "husky": "^9.1.7",
     "installed-check": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "type": "module",
   "exports": "./index.cjs",
   "engines": {
-    "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+    "node": "^20.19.0 || ^22.13.0 || >=24.0.0",
+    "typescript": ">=5.9"
   },
   "files": [
     "index.cjs",

--- a/test/format-results.test.js
+++ b/test/format-results.test.js
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { format } from '../lib/format-results.js';
+
+/** @type {import('eslint').ESLint.LintResult[]} */
+const fixture = /** @type {any} */ ([
+  {
+    filePath: '/proj/src/a.js',
+    messages: [
+      { ruleId: 'no-unused-vars', severity: 2, line: 1, column: 1, message: 'x' },
+      { ruleId: 'no-unused-vars', severity: 2, line: 2, column: 1, message: 'x' },
+      { ruleId: 'no-undef', severity: 2, line: 3, column: 1, message: 'y' },
+      { ruleId: 'semi', severity: 1, fix: { range: [0, 0], text: ';' }, line: 4, column: 1, message: 'z' },
+    ],
+  },
+  {
+    filePath: '/proj/src/b.js',
+    messages: [
+      { ruleId: 'no-undef', severity: 2, line: 1, column: 1, message: 'y' },
+      { ruleId: 'semi', severity: 1, fix: { range: [0, 0], text: ';' }, line: 2, column: 1, message: 'z' },
+    ],
+  },
+]);
+
+test('format() csv has header and one row per rule', () => {
+  const out = format(fixture, { cwd: '/proj', output: 'csv' });
+  const lines = out.split('\n');
+  assert.equal(lines[0], 'errors,warnings,fixable,rule');
+  assert.equal(lines.length, 4);
+  assert.ok(lines.some(l => l === '2,0,0,"no-unused-vars"'), `missing no-unused-vars row; got:\n${out}`);
+  assert.ok(lines.some(l => l === '2,0,0,"no-undef"'));
+  assert.ok(lines.some(l => l === '0,2,2,"semi"'));
+});
+
+test('format() csv escapes quotes in rule ids', () => {
+  /** @type {import('eslint').ESLint.LintResult[]} */
+  const quoted = /** @type {any} */ ([{
+    filePath: '/p/a.js',
+    messages: [{ ruleId: 'weird"rule', severity: 2, line: 1, column: 1, message: 'x' }],
+  }]);
+  const out = format(quoted, { cwd: '/p', output: 'csv' });
+  assert.match(out, /"weird""rule"/);
+});
+
+test('format() csv sorts by errors desc by default, then by rule id', () => {
+  const out = format(fixture, { cwd: '/proj', output: 'csv' });
+  const rows = out.split('\n').slice(1);
+  // both no-unused-vars and no-undef have 2 errors; tiebreak by ruleId asc
+  assert.equal(rows[0], '2,0,0,"no-undef"');
+  assert.equal(rows[1], '2,0,0,"no-unused-vars"');
+  assert.equal(rows[2], '0,2,2,"semi"');
+});
+
+test('format() csv sorts by warnings when sortByProp=warnings', () => {
+  const out = format(fixture, { cwd: '/proj', output: 'csv', sortByProp: 'warnings' });
+  const rows = out.split('\n').slice(1);
+  assert.equal(rows[0], '0,2,2,"semi"');
+});
+
+test('format() markdown produces a table with expected columns', () => {
+  const out = format(fixture, { cwd: '/proj', output: 'markdown' });
+  assert.match(out, /\| Errors +\| Warnings +\| Fixable +\| Rule +\|/);
+  assert.match(out, /no-unused-vars/);
+  assert.match(out, /<details><summary>/);
+});
+
+test('format() markdown renders rule docs links when rulesMeta provides url', () => {
+  const out = format(fixture, {
+    cwd: '/proj',
+    output: 'markdown',
+    rulesMeta: {
+      semi: { docs: { url: 'https://example.test/semi' } },
+    },
+  });
+  assert.match(out, /\[semi\]\(https:\/\/example\.test\/semi\)/);
+});
+
+test('format() default CLI output contains header, rule rows, and totals', () => {
+  const out = format(fixture, { cwd: '/proj' });
+  assert.ok(out.includes('Summary of failing ESLint rules'));
+  assert.ok(out.includes('no-unused-vars'));
+  assert.ok(out.includes('problems in total'));
+  assert.ok(out.includes('fixable'));
+});
+
+test('format() sortReverse inverts order', () => {
+  const forward = format(fixture, { cwd: '/proj', output: 'csv' });
+  const reversed = format(fixture, { cwd: '/proj', output: 'csv', sortReverse: true });
+  const forwardRows = forward.split('\n').slice(1);
+  const reversedRows = reversed.split('\n').slice(1);
+  assert.deepEqual([...forwardRows].reverse(), reversedRows);
+});

--- a/test/index.cjs.test.js
+++ b/test/index.cjs.test.js
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+/** @type {(results: import('eslint').ESLint.LintResult[], ctx: import('eslint').ESLint.LintResultData) => Promise<string>} */
+const formatter = require('../index.cjs');
+
+/** @type {import('eslint').ESLint.LintResult[]} */
+const fixture = /** @type {any} */ ([{
+  filePath: '/proj/src/a.js',
+  errorCount: 1,
+  warningCount: 1,
+  messages: [
+    { ruleId: 'no-undef', severity: 2, line: 1, column: 1, message: 'x' },
+    { ruleId: 'semi', severity: 1, fix: { range: [0, 0], text: ';' }, line: 2, column: 1, message: 'z' },
+  ],
+}]);
+
+/** @type {import('eslint').ESLint.LintResult[]} */
+const cleanFixture = /** @type {any} */ ([{
+  filePath: '/proj/src/clean.js',
+  errorCount: 0,
+  warningCount: 0,
+  messages: [],
+}]);
+
+/** @type {import('eslint').ESLint.LintResultData} */
+const context = { cwd: '/proj', rulesMeta: {} };
+
+test('index.cjs returns CLI-formatted string by default', async () => {
+  const out = await formatter(fixture, context);
+  assert.ok(out.includes('no-undef'));
+  assert.ok(out.includes('problems in total'));
+});
+
+test('index.cjs honors EFS_OUTPUT=csv', async () => {
+  const prev = process.env['EFS_OUTPUT'];
+  process.env['EFS_OUTPUT'] = 'csv';
+  try {
+    const out = await formatter(fixture, context);
+    assert.match(out, /^errors,warnings,fixable,rule\n/);
+  } finally {
+    if (prev === undefined) delete process.env['EFS_OUTPUT'];
+    else process.env['EFS_OUTPUT'] = prev;
+  }
+});
+
+test('index.cjs appends markdown to $GITHUB_STEP_SUMMARY when set', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'efs-'));
+  const summaryPath = join(dir, 'step.md');
+  const prev = process.env['GITHUB_STEP_SUMMARY'];
+  process.env['GITHUB_STEP_SUMMARY'] = summaryPath;
+  try {
+    await formatter(fixture, context);
+    const body = readFileSync(summaryPath, 'utf8');
+    assert.match(body, /\| Errors +\| Warnings +\| Fixable +\| Rule +\|/);
+    assert.match(body, /no-undef/);
+  } finally {
+    if (prev === undefined) delete process.env['GITHUB_STEP_SUMMARY'];
+    else process.env['GITHUB_STEP_SUMMARY'] = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('index.cjs appends (not overwrites) on repeated invocations', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'efs-'));
+  const summaryPath = join(dir, 'step.md');
+  const prev = process.env['GITHUB_STEP_SUMMARY'];
+  process.env['GITHUB_STEP_SUMMARY'] = summaryPath;
+  try {
+    await formatter(fixture, context);
+    await formatter(fixture, context);
+    const body = readFileSync(summaryPath, 'utf8');
+    const occurrences = body.match(/\| Errors /g)?.length ?? 0;
+    assert.equal(occurrences, 2);
+  } finally {
+    if (prev === undefined) delete process.env['GITHUB_STEP_SUMMARY'];
+    else process.env['GITHUB_STEP_SUMMARY'] = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('index.cjs does not write $GITHUB_STEP_SUMMARY on a clean run', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'efs-'));
+  const summaryPath = join(dir, 'step.md');
+  const prev = process.env['GITHUB_STEP_SUMMARY'];
+  process.env['GITHUB_STEP_SUMMARY'] = summaryPath;
+  try {
+    await formatter(cleanFixture, context);
+    assert.equal(existsSync(summaryPath), false);
+  } finally {
+    if (prev === undefined) delete process.env['GITHUB_STEP_SUMMARY'];
+    else process.env['GITHUB_STEP_SUMMARY'] = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+for (const optOutValue of ['false', '0']) {
+  test(`index.cjs skips write when EFS_GITHUB_STEP_SUMMARY=${optOutValue}`, async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'efs-'));
+    const summaryPath = join(dir, 'step.md');
+    const prevSummary = process.env['GITHUB_STEP_SUMMARY'];
+    const prevOptOut = process.env['EFS_GITHUB_STEP_SUMMARY'];
+    process.env['GITHUB_STEP_SUMMARY'] = summaryPath;
+    process.env['EFS_GITHUB_STEP_SUMMARY'] = optOutValue;
+    try {
+      await formatter(fixture, context);
+      assert.equal(existsSync(summaryPath), false);
+    } finally {
+      if (prevSummary === undefined) delete process.env['GITHUB_STEP_SUMMARY'];
+      else process.env['GITHUB_STEP_SUMMARY'] = prevSummary;
+      if (prevOptOut === undefined) delete process.env['EFS_GITHUB_STEP_SUMMARY'];
+      else process.env['EFS_GITHUB_STEP_SUMMARY'] = prevOptOut;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}
+
+test('index.cjs still returns output when $GITHUB_STEP_SUMMARY write fails', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'efs-'));
+  const blocker = join(dir, 'blocker');
+  writeFileSync(blocker, 'x', 'utf8');
+  // Append to a path that treats `blocker` as a directory — ENOTDIR.
+  const summaryPath = join(blocker, 'step.md');
+  const prev = process.env['GITHUB_STEP_SUMMARY'];
+  process.env['GITHUB_STEP_SUMMARY'] = summaryPath;
+  try {
+    const out = await formatter(fixture, context);
+    assert.ok(out.includes('no-undef'));
+    assert.equal(existsSync(summaryPath), false);
+  } finally {
+    if (prev === undefined) delete process.env['GITHUB_STEP_SUMMARY'];
+    else process.env['GITHUB_STEP_SUMMARY'] = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Aligns `.gitignore` with [`voxpelli/node-module-template`](https://github.com/voxpelli/node-module-template).
- Declares `engines.typescript: ">=5.9"` so the tsc floor is explicit.
- Adds a `node:test` + `c8` unit test suite covering `lib/*` and `index.cjs` (16 tests, 100% line coverage).

Tests include three new behaviors introduced in #21:
- skip the `$GITHUB_STEP_SUMMARY` write on clean runs,
- honor the `EFS_GITHUB_STEP_SUMMARY=false|0` opt-out,
- keep returning formatter output when the summary write fails (ENOTDIR path).

## Test plan

- [x] `npm run test:node` → 16/16 pass, 100% line coverage
- [x] `npm run check` → lint, tsc, type-coverage, installed-check, knip all clean
- [ ] CI green across Node 20 / 22 / 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)